### PR TITLE
feat: User creattion consumer for pokemon collection logic

### DIFF
--- a/pokemon-service/cmd/main.go
+++ b/pokemon-service/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 	router := gin.Default()
 	router.Use(cors.Default())
 
-	router.Use(cors.Default())
+	go controllers.StartUserCreationConsumer()
 	if err := router.Run(port); err != nil {
 		log.Printf("failed to run the server: %v", err)
 	}

--- a/pokemon-service/controllers/main.go
+++ b/pokemon-service/controllers/main.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"context"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
@@ -10,6 +12,7 @@ var (
 	RedisClient       *redis.Client
 	DBClient          *gorm.DB
 	UserTopicConsumer *kafka.Consumer
+	ctxBackground     = context.Background()
 	UserTopic         = "users"
 )
 

--- a/pokemon-service/controllers/user-creation-consumer.go
+++ b/pokemon-service/controllers/user-creation-consumer.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"os/signal"
+	"pokemon-service/pkg/models"
+	"syscall"
+	"time"
+)
+
+func StartUserCreationConsumer() {
+	log.Println("Starting the user creation consumer")
+
+	// Infinite loop to keep the consumer alivesigChan := make(chan os.Signal, 1)
+	UserTopicConsumer.SubscribeTopics([]string{UserTopic}, nil)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigChan
+		log.Println("Received termination signal. Stopping the user creation consumer")
+		os.Exit(1)
+	}()
+	for {
+		select {
+		case <-ctxBackground.Done():
+			log.Println("User Creation Consumer has stopped")
+			return
+		default:
+		}
+
+		msg, err := UserTopicConsumer.ReadMessage(100 * time.Millisecond)
+		if err != nil {
+			log.Printf("Error reading message from Kafka: %v", err)
+			continue
+		}
+
+		user := models.User{}
+		if err := json.Unmarshal(msg.Value, &user); err != nil {
+			log.Printf("Error unmarshalling message: %v", err)
+			continue
+		}
+
+		// debug
+		fmt.Printf("User Creation Message: %d, email: %s, password: %s, email: %s\n", user.ID, user.Email, user.Password, user.Email)
+
+		// Assign the user one of the starters from the games :easter-egg:
+		starterPokemon := [4]int{1, 4, 7, 25}
+		UserPokemon := models.User_Pokemon{}
+		UserPokemon.UserId = user.ID
+		UserPokemon.PokemonId = starterPokemon[rand.IntN(3-0)+0]
+		if DBClient.Create(&UserPokemon).Error != nil {
+			log.Fatal(err)
+			return
+		}
+
+		//TODO Update collection in Redis
+	}
+}

--- a/pokemon-service/init/db.go
+++ b/pokemon-service/init/db.go
@@ -19,7 +19,8 @@ func ConnectDB() *gorm.DB {
 	sqlDB.SetMaxIdleConns(10)
 	sqlDB.SetMaxOpenConns(100)
 	sqlDB.SetConnMaxLifetime(time.Hour)
-	db.AutoMigrate(models.Pokemon{}) // Migrate the Pokemon model
+	db.AutoMigrate(models.Pokemon{})      // Migrate the Pokemon model
+	db.AutoMigrate(models.User_Pokemon{}) // Migrate the User_Pokemon model
 
 	return db
 }

--- a/pokemon-service/pkg/models/user.go
+++ b/pokemon-service/pkg/models/user.go
@@ -1,0 +1,9 @@
+package models
+
+// Model for user data type
+type User struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}

--- a/pokemon-service/pkg/models/user_pokemon.go
+++ b/pokemon-service/pkg/models/user_pokemon.go
@@ -1,0 +1,6 @@
+package models
+
+type User_Pokemon struct {
+	UserId    int `json:"user_id"`
+	PokemonId int `json:pokemon_id"`
+}


### PR DESCRIPTION
- Add logic for the user creation consumer from kafka
- Create a new collection when the user creation message is received
- Assign the user their first pokemon to start their collection